### PR TITLE
update parsing to handle new shmoop.com layout

### DIFF
--- a/get_summaries.py
+++ b/get_summaries.py
@@ -103,6 +103,10 @@ for k, (_, title, url, _, _) in enumerate(summary_infos):
                 list_id = candidate_id + 1
                 break
 
+        if list_id = None:
+            print("Couldn't find containing list for {} {}!  Skipping...".format(index, section_url))
+            continue
+
         summary_bullets = candidate_lists[list_id].findAll("li")
 
         lines = [bullet.text for bullet in summary_bullets]

--- a/get_summaries.py
+++ b/get_summaries.py
@@ -103,7 +103,7 @@ for k, (_, title, url, _, _) in enumerate(summary_infos):
                 list_id = candidate_id + 1
                 break
 
-        if list_id = None:
+        if list_id is None:
             print("Couldn't find containing list for {} {}!  Skipping...".format(index, section_url))
             continue
 


### PR DESCRIPTION
updated the parsing in get_summaries.com to handle the new layout of shmoop.com; not sure what it used to look like (from the parser, it seems like the summaries for all the chapters in each book were on one very large page) but now there's a sidebar with links to the sections.  had to do some hacky stuff to deal with the fact that the website no longer has ways to uniquely identifying HTML elements.  spot checked 4-5 of the novel summaries randomly and they look right but if you'd like to do a diff with your original extraction just let me know!